### PR TITLE
Debug

### DIFF
--- a/cosmotheka/mappers/mapper_CatWISE.py
+++ b/cosmotheka/mappers/mapper_CatWISE.py
@@ -25,7 +25,7 @@ class MapperCatWISE(MapperBase):
         self.apply_ecliptic_correction = \
             config.get('apply_ecliptic_correction', True)
         self.cat_data = None
-        self.nmap_data = None
+        self.nmap_data = {'corr': None, 'uncorr': None}
         self.ecliptic_corr = None
 
         self.npix = hp.nside2npix(self.nside)
@@ -54,7 +54,7 @@ class MapperCatWISE(MapperBase):
     def _get_ecliptic_correction(self):
         # Correction to Density
         if self.ecliptic_corr is None:
-            pixarea_deg2 = (hp.nside2resol(self.nside, arcmin=True)/60)**2
+            pixarea_deg2 = hp.nside2pixarea(self.nside, degrees=True)
             # Transforms equatorial to ecliptic coordinates
             r = hp.Rotator(coord=[self.coords, 'E'])
             # Get coordinates in system of choice
@@ -68,24 +68,25 @@ class MapperCatWISE(MapperBase):
 
         return self.ecliptic_corr
 
-    def _get_nmap_data(self):
-        if self.nmap_data is None:
+    def _get_nmap_data(self, corr=True):
+        if corr:
+            key = 'corr'
+        else:
+            key = 'uncorr'
+
+        if self.nmap_data[key] is None:
             cat_data = self.get_catalog()
             nmap_data = get_map_from_points(cat_data, self.nside,
                                             rot=self.rot, ra_name='ra',
                                             dec_name='dec')
+            self.nmap_data['uncorr'] = nmap_data
             # ecliptic latitude correction -- SvH 5/3/22
             if self.apply_ecliptic_correction:
                 print('Applying the ecliptic correction')
                 correction = self._get_ecliptic_correction()
-            else:
-                correction = np.zeros_like(nmap_data)
-            # Following Cell 19, this correction is done by subtracting:
-            # https://github.com/rameez3333/CatWISEdipole/blob/main/CatWISE_Dipole_Results.ipynb
-            nmap_data = nmap_data - correction
-            nmap_data[nmap_data < 0] = 0
-            self.nmap_data = nmap_data
-        return self.nmap_data
+                self.nmap_data['corr'] = nmap_data + correction
+
+        return self.nmap_data[key]
 
     # Density Map
     def _get_signal_map(self):
@@ -114,8 +115,8 @@ class MapperCatWISE(MapperBase):
                                               30))] = 0
         if self.file_sourcemask is not None:
             # holes catalog
-            mask_holes = Table.read(self.file_sourcemask,
-                                    format='ascii.commented_header')
+            mask_holes = Table.read(self.file_sourcemask)
+                                    # format='ascii.commented_header')
             vecmask = hp.ang2vec(mask_holes['ra'],
                                  mask_holes['dec'],
                                  lonlat=True)
@@ -133,10 +134,8 @@ class MapperCatWISE(MapperBase):
         # Otherwise, it calculates using "_cut_mask()". \
         # It also rotates the mask to the chose coordinates.
 
-        # TODO: What's this mask_file? What's file_mask in the config file?
-        # The file_mask config file is not understood by healpy.
-        if self.config.get('mask_file', None) is not None:
-            mask = hp.ud_grade(hp.read_map(self.config['mask_file']),
+        if self.config.get('file_mask', None) is not None:
+            mask = hp.ud_grade(hp.read_map(self.config['file_mask']),
                                nside_out=self.nside)
         else:
             mask = self._cut_mask()
@@ -148,9 +147,14 @@ class MapperCatWISE(MapperBase):
         if self.nl_coupled is None:
             mask = self.get_mask()
             nmap_data = self._get_nmap_data()
+            # Only the observed galaxies contribute to the variance (and,
+            # therefore, the shot noise)
+            nmap_data_uncorr = self._get_nmap_data(corr=False)
             N_mean = np.average(nmap_data, weights=mask)
+            N_mean_uncorr = np.average(nmap_data_uncorr, weights=mask)
             N_mean_srad = N_mean * self.npix / (4 * np.pi)
-            N_ell = np.mean(mask) / N_mean_srad
+            N_mean_srad_uncorr = N_mean_uncorr * self.npix / (4 * np.pi)
+            N_ell = np.mean(mask) * N_mean_srad_uncorr / N_mean_srad**2
             self.nl_coupled = N_ell * np.ones((1, 3*self.nside))
         return self.nl_coupled
 

--- a/cosmotheka/mappers/mapper_CatWISE.py
+++ b/cosmotheka/mappers/mapper_CatWISE.py
@@ -117,7 +117,6 @@ class MapperCatWISE(MapperBase):
         if self.file_sourcemask is not None:
             # holes catalog
             mask_holes = Table.read(self.file_sourcemask)
-                                    # format='ascii.commented_header')
             vecmask = hp.ang2vec(mask_holes['ra'],
                                  mask_holes['dec'],
                                  lonlat=True)

--- a/cosmotheka/mappers/mapper_CatWISE.py
+++ b/cosmotheka/mappers/mapper_CatWISE.py
@@ -148,9 +148,9 @@ class MapperCatWISE(MapperBase):
         if self.nl_coupled is None:
             mask = self.get_mask()
             nmap_data = self._get_nmap_data()
-            N_mean = np.average(nmap_data, weights=self.mask)
+            N_mean = np.average(nmap_data, weights=mask)
             N_mean_srad = N_mean * self.npix / (4 * np.pi)
-            N_ell = np.mean(self.mask) / N_mean_srad
+            N_ell = np.mean(mask) / N_mean_srad
             self.nl_coupled = N_ell * np.ones((1, 3*self.nside))
         return self.nl_coupled
 

--- a/cosmotheka/mappers/mapper_CatWISE.py
+++ b/cosmotheka/mappers/mapper_CatWISE.py
@@ -80,6 +80,7 @@ class MapperCatWISE(MapperBase):
                                             rot=self.rot, ra_name='ra',
                                             dec_name='dec')
             self.nmap_data['uncorr'] = nmap_data
+            self.nmap_data['corr'] = nmap_data
             # ecliptic latitude correction -- SvH 5/3/22
             if self.apply_ecliptic_correction:
                 print('Applying the ecliptic correction')

--- a/cosmotheka/mappers/mapper_HSC_DR1wl.py
+++ b/cosmotheka/mappers/mapper_HSC_DR1wl.py
@@ -100,7 +100,7 @@ class MapperHSCDR1wl(MapperBase):
                   cat[f'{isn}_derived_shear_bias_c1']) / (1 + mhat)
             e2 = (cat[f'{isn}_e2']/(2.*resp) -
                   cat[f'{isn}_derived_shear_bias_c2']) / (1 + mhat)
-            cat['e1'] = -e1
+            cat['e1'] = e1
             cat['e2'] = e2
 
             # Remove unnecessary columns
@@ -196,7 +196,7 @@ class MapperHSCDR1wl(MapperBase):
         cat = self.get_catalog()
         we1, we2 = get_map_from_points(cat, self.nside,
                                        w=cat[self.w_name],
-                                       qu=[cat['e1'], cat['e2']],
+                                       qu=[-cat['e1'], -cat['e2']],
                                        ra_name='ra',
                                        dec_name='dec',
                                        rot=self.rot)

--- a/cosmotheka/mappers/mapper_HSC_DR1wl.py
+++ b/cosmotheka/mappers/mapper_HSC_DR1wl.py
@@ -100,7 +100,7 @@ class MapperHSCDR1wl(MapperBase):
                   cat[f'{isn}_derived_shear_bias_c1']) / (1 + mhat)
             e2 = (cat[f'{isn}_e2']/(2.*resp) -
                   cat[f'{isn}_derived_shear_bias_c2']) / (1 + mhat)
-            cat['e1'] = e1
+            cat['e1'] = -e1
             cat['e2'] = e2
 
             # Remove unnecessary columns

--- a/cosmotheka/tests/test_mapper_CatWISE.py
+++ b/cosmotheka/tests/test_mapper_CatWISE.py
@@ -67,8 +67,7 @@ def test_get_nmap_data(corr):
         assert np.all(nmap == 1)
     else:
         # It's 0 because the ecliptic_correction is -11.28, and nmap > 0.
-        nmap_ref = 1 - m._get_ecliptic_correction()
-        nmap_ref[nmap_ref < 0] = 0
+        nmap_ref = 1 + m._get_ecliptic_correction()
         assert np.all(nmap == nmap_ref)
     clean_fake_data()
 
@@ -86,8 +85,7 @@ def test_get_signal_map(corr):
     if corr is False:
         assert np.all(np.fabs(d) < 1E-5)
     else:
-        nmap_ref = 1 - m._get_ecliptic_correction()
-        nmap_ref[nmap_ref < 0] = 0
+        nmap_ref = 1 + m._get_ecliptic_correction()
         dref = nmap_ref / np.mean(nmap_ref) - 1
         assert np.all(np.fabs(d/dref - 1) < 1E-5)
     clean_fake_data()
@@ -103,15 +101,17 @@ def test_get_nl_coupled(corr):
     nl = m.get_nl_coupled()
     nl = np.array(nl)
     pix_area = 4*np.pi/hp.nside2npix(m.nside)
-    nl_pred = hp.nside2npix(32)
-    nl_pred *= pix_area**2/(4*np.pi)
     assert nl.shape == (1, 3*m.nside)
     if corr is False:
+        nl_pred = pix_area
         assert np.all(np.fabs(nl/nl_pred-1) < 1E-10)
     else:
-        nmap_ref = 1 - m._get_ecliptic_correction()
-        nmap_ref[nmap_ref < 0] = 0
-        nl_pred /= np.mean(nmap_ref)
+        nmap_ref = 1 + m._get_ecliptic_correction()
+
+        nmean_srad = np.mean(nmap_ref) / pix_area
+        nmean_srad_uncorr = 1 / pix_area
+
+        nl_pred = nmean_srad_uncorr / nmean_srad**2
         assert np.all(np.fabs(nl/nl_pred-1) < 1E-10)
     clean_fake_data()
 

--- a/cosmotheka/tests/test_mapper_CatWISE.py
+++ b/cosmotheka/tests/test_mapper_CatWISE.py
@@ -2,15 +2,16 @@ import numpy as np
 import cosmotheka as xc
 import healpy as hp
 import os
+import pytest
 from astropy.table import Table
 
 
-def get_config():
+def get_config(corr=True):
     data_path = 'cosmotheka/tests/data/'
     return {'data_catalog': data_path+'catalog_CatWISE.fits',
             'mask_sources': data_path+'MASKS_exclude_master_final.fits',
             'nside': 32, 'mask_name': 'mask', 'coords': 'C',
-            'apply_ecliptic_correction': True}
+            'apply_ecliptic_correction': corr}
 
 
 def make_fake_data():
@@ -52,24 +53,50 @@ def test_get_mask():
     assert np.all(np.fabs(d-1) == 0)
 
 
-def test_get_signal_map():
+@pytest.mark.parametrize('corr', [True, False])
+def test_get_nmap_data(corr):
     make_fake_data()
-    config = get_config()
+    config = get_config(corr)
     config['GLAT_max_deg'] = 0.
     config.pop('mask_sources')
     m = xc.mappers.MapperCatWISE(config)
-    m.apply_ecliptic_correction = False
-    d = m.get_signal_map()
-    d = np.array(d)
-    print(d)
-    assert d.shape == (1, hp.nside2npix(m.nside))
-    assert np.all(np.fabs(d) < 1E-5)
+    nmap = m._get_nmap_data()
+
+    assert nmap.size == hp.nside2npix(m.nside)
+    if corr is False:
+        assert np.all(nmap == 1)
+    else:
+        # It's 0 because the ecliptic_correction is -11.28, and nmap > 0.
+        nmap_ref = 1 - m._get_ecliptic_correction()
+        nmap_ref[nmap_ref < 0] = 0
+        assert np.all(nmap == nmap_ref)
     clean_fake_data()
 
 
-def test_get_nl_coupled():
+@pytest.mark.parametrize('corr', [True, False])
+def test_get_signal_map(corr):
     make_fake_data()
-    config = get_config()
+    config = get_config(corr)
+    config['GLAT_max_deg'] = 0.
+    config.pop('mask_sources')
+    m = xc.mappers.MapperCatWISE(config)
+    d = m.get_signal_map()
+    d = np.array(d)
+    assert d.shape == (1, hp.nside2npix(m.nside))
+    if corr is False:
+        assert np.all(np.fabs(d) < 1E-5)
+    else:
+        nmap_ref = 1 - m._get_ecliptic_correction()
+        nmap_ref[nmap_ref < 0] = 0
+        dref = nmap_ref / np.mean(nmap_ref) - 1
+        assert np.all(np.fabs(d/dref - 1) < 1E-5)
+    clean_fake_data()
+
+
+@pytest.mark.parametrize('corr', [True, False])
+def test_get_nl_coupled(corr):
+    make_fake_data()
+    config = get_config(corr)
     config['GLAT_max_deg'] = 0.
     config.pop('mask_sources')
     m = xc.mappers.MapperCatWISE(config)
@@ -79,7 +106,13 @@ def test_get_nl_coupled():
     nl_pred = hp.nside2npix(32)
     nl_pred *= pix_area**2/(4*np.pi)
     assert nl.shape == (1, 3*m.nside)
-    assert np.all(np.fabs(nl/nl_pred-1) < 1E-10)
+    if corr is False:
+        assert np.all(np.fabs(nl/nl_pred-1) < 1E-10)
+    else:
+        nmap_ref = 1 - m._get_ecliptic_correction()
+        nmap_ref[nmap_ref < 0] = 0
+        nl_pred /= np.mean(nmap_ref)
+        assert np.all(np.fabs(nl/nl_pred-1) < 1E-10)
     clean_fake_data()
 
 

--- a/cosmotheka/tests/test_mapper_HSCDR1wl.py
+++ b/cosmotheka/tests/test_mapper_HSCDR1wl.py
@@ -171,8 +171,8 @@ def test_get_signal_map():
     mask = m.get_mask()
     assert sh.shape == (2, hp.nside2npix(32))
     assert np.all(mask == 1.0)
-    assert np.all((sh[0]-1.0) < 1E-5)
-    assert np.all((sh[1]+1.0) < 1E-5)
+    assert np.all((sh[0]+1.0) < 1E-5)
+    assert np.all((sh[1]-1.0) < 1E-5)
     clean_hsc_data()
     remove_rerun(prerun)
 

--- a/input/CatWISE.yml
+++ b/input/CatWISE.yml
@@ -1,6 +1,6 @@
 mapper_class: MapperCatWISE
 data_catalog: /mnt/extraspace/damonge/Datasets/CatWISE/catwise_agns_masked_final_w1lt16p5_alpha.fits
-file_mask: /mnt/extraspace/damonge/Datasets/CatWISE/MASKS_exclude_master_final.fits
+mask_sources: /mnt/extraspace/damonge/Datasets/CatWISE/MASKS_exclude_master_final.fits
 apply_ecliptic_correction: True
 mask_name: mask_CatWISE
 path_rerun: '/mnt/extraspace/damonge/Datasets/CatWISE/xcell_runs'

--- a/run_cls.py
+++ b/run_cls.py
@@ -7,6 +7,7 @@ import numpy as np
 import re
 from datetime import datetime
 from glob import glob
+import sys
 
 
 ##############################################################################
@@ -49,7 +50,8 @@ def get_pyexec(comment, nc, queue, mem, onlogin, outdir, batches=False, logfname
     if batches:
         pyexec = ""
     else:
-        pyexec = "/usr/local/shared/python3.9.7/bin/python3"
+        # Use the same python that launched run_cls.py
+        pyexec = sys.executable
 
     if not onlogin:
         logdir = os.path.join(outdir, 'log')


### PR DESCRIPTION
Fixed HSC and CatWISE mappers. 
 - For HSC, I have inverted the sign of the shear component e1. HCS x DECALS was also negative, so I think this is the right thing to do. 
 - For CatWISE, I have changed the way the ecliptic correction is applied: it is now subtracted, following the Cell 19 of https://github.com/rameez3333/CatWISEdipole/blob/main/CatWISE_Dipole_Results.ipynb and have made sure the number counts map is always positive. I am unsure why we have to multiply by the pixel area since by Cell 19 it seems that they obtain `rho_nc = fit * ecliptic_map / Area`, so the number count map should be `fit * ecliptic_map`. 