### PR TITLE
Fix MC correction cache

### DIFF
--- a/cosmotheka/cls/cl.py
+++ b/cosmotheka/cls/cl.py
@@ -876,12 +876,13 @@ class Cl(ClBase):
         # as in Sailer. It is supposed to be more numerically stable.
         for i, (rec_sim, input_sim) in enumerate(zip(rec_sims, input_sims)):
             # If step already computed, read it and append it to the list.
-            if d is not None and d['computed'] < i:
+            if d is not None and i < d['computed']:
                 print(f"Reading step {i+1} / {nsims}", flush=True)
                 num.append(d['num'][i])
                 denom.append(d['denom'][i])
                 num_cp.append(d['num_cp'][i])
                 denom_cp.append(d['denom_cp'][i])
+                continue
 
             # If not already computed, compute it.
             print(f"Computing Tl {i+1} / {nsims}", flush=True)

--- a/cosmotheka/tests/test_cls.py
+++ b/cosmotheka/tests/test_cls.py
@@ -1406,7 +1406,8 @@ def test_mc_correction_resumes_partial_file(monkeypatch):
     input_sims = ["in0", "in1"]
     mapper_cmbk._get_sims_fnames = lambda: (rec_sims, input_sims)
     mapper_cmbk.get_mask = lambda: np.array([1.0])
-    mapper_cmbk._get_map_from_alm_file = lambda path: np.array([0.0 if path.endswith("0") else 1.0])
+    mapper_cmbk._get_map_from_alm_file = \
+        lambda path: np.array([0.0 if path.endswith("0") else 1.0])
     mapper_x.get_mask = lambda: np.array([1.0])
     mapper_x.coords = "C"
 
@@ -1423,7 +1424,9 @@ def test_mc_correction_resumes_partial_file(monkeypatch):
 
     def fake_compute_coupled_cell(field1, field2):
         call_count["n"] += 1
-        value = float(field1["map"][0] + 10 * field2["map"][0] + call_count["n"])
+        value = float(
+            field1["map"][0] + 10 * field2["map"][0] + call_count["n"]
+            )
         return np.array([[value]])
 
     monkeypatch.setattr(nmt, "NmtField", fake_nmt_field)

--- a/cosmotheka/tests/test_cls.py
+++ b/cosmotheka/tests/test_cls.py
@@ -1393,3 +1393,65 @@ def test_mc_correction():
     # I can get rel 1e-4 in Glamdring but not in the CI, so I relax the
     # tolerance to 1e-3
     assert Tl == pytest.approx(ones, rel=1e-3, abs=0)
+
+
+def test_mc_correction_resumes_partial_file(monkeypatch):
+    config = get_config(dtype0="cmb_convergence", fsky=1.0, fsky2=0.1)
+    config["cls"]["Dummy-Dummy"]["neglect_mc_correction"] = False
+    cl_class = Cl(config, "Dummy__0", "Dummy__1")
+    mapper_cmbk, mapper_x = cl_class.get_mappers()
+
+    # Keep the test tiny: only two MC steps, one of them already stored.
+    rec_sims = ["rec0", "rec1"]
+    input_sims = ["in0", "in1"]
+    mapper_cmbk._get_sims_fnames = lambda: (rec_sims, input_sims)
+    mapper_cmbk.get_mask = lambda: np.array([1.0])
+    mapper_cmbk._get_map_from_alm_file = lambda path: np.array([0.0 if path.endswith("0") else 1.0])
+    mapper_x.get_mask = lambda: np.array([1.0])
+    mapper_x.coords = "C"
+
+    class FakeWorkspace:
+        def decouple_cell(self, cl_cp):
+            return cl_cp
+
+    cl_class.get_workspace_spin0 = lambda: FakeWorkspace()
+
+    call_count = {"n": 0}
+
+    def fake_nmt_field(mask, maps, spin=None):
+        return {"mask": np.asarray(mask), "map": np.asarray(maps[0])}
+
+    def fake_compute_coupled_cell(field1, field2):
+        call_count["n"] += 1
+        value = float(field1["map"][0] + 10 * field2["map"][0] + call_count["n"])
+        return np.array([[value]])
+
+    monkeypatch.setattr(nmt, "NmtField", fake_nmt_field)
+    monkeypatch.setattr(nmt, "compute_coupled_cell", fake_compute_coupled_cell)
+
+    outdir = cl_class.outdir
+    os.makedirs(outdir, exist_ok=True)
+    fname = os.path.join(outdir, "Tl_mask_dummy0_mask_dummy1_coordC_ns32.npz")
+    np.savez_compressed(
+        fname,
+        Tl=np.array([1.0]),
+        Tl_cp=np.array([2.0]),
+        ell=np.array([0.0]),
+        num=np.array([[11.0]]),
+        denom=np.array([[12.0]]),
+        num_cp=np.array([[13.0]]),
+        denom_cp=np.array([[14.0]]),
+        computed=1,
+    )
+
+    Tl, Tl_cp = cl_class.get_correction_cmbk()
+
+    # One precomputed step was reused, so only the missing step should be
+    # evaluated here, which means two coupled-cell calls total.
+    assert call_count["n"] == 2
+    assert np.all(np.isfinite(Tl))
+    assert np.all(np.isfinite(Tl_cp))
+    saved = np.load(fname)
+    assert saved["computed"] == 2
+    assert saved["num"][0] == pytest.approx(11.0)
+    assert saved["denom"][0] == pytest.approx(12.0)

--- a/run_cls_mpi.py
+++ b/run_cls_mpi.py
@@ -1,14 +1,92 @@
 #!/usr/bin/python
+import json
+import hashlib
 import os
 from cosmotheka.cls.data import Data
 from cosmotheka.cls.cl import Cl, ClFid
 from cosmotheka.cls.cov import Cov
 from cosmotheka.cls.to_sacc import ClSack
-from mpi4py import MPI
 
-COMM = MPI.COMM_WORLD
+try:
+    from mpi4py import MPI
+except ImportError:
+    MPI = None
+
+
+class _SingleProcessComm:
+    def Get_rank(self):
+        return 0
+
+    def Get_size(self):
+        return 1
+
+    def Barrier(self):
+        return None
+
+    def bcast(self, value, root=0):
+        return value
+
+    def Abort(self, errorcode=1):
+        raise SystemExit(errorcode)
+
+COMM = MPI.COMM_WORLD if MPI is not None else _SingleProcessComm()
 RANK = COMM.Get_rank()
 SIZE = COMM.Get_size()
+
+
+def get_stage_status_path(data):
+    return os.path.join(data.data["output"], ".run_cls_mpi_status.json")
+
+
+def get_config_signature(data):
+    payload = json.dumps(data.data, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def load_stage_status(data):
+    fname = get_stage_status_path(data)
+    if not os.path.isfile(fname):
+        return {}
+
+    try:
+        with open(fname, "r") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_stage_status(data, status):
+    if RANK != 0:
+        return
+
+    fname = get_stage_status_path(data)
+    tmp_fname = f"{fname}.tmp"
+    with open(tmp_fname, "w") as f:
+        json.dump(status, f, indent=2, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp_fname, fname)
+
+
+def stage_is_complete(data, stage, params=None):
+    status = load_stage_status(data)
+    record = status.get(stage)
+    if not record or not record.get("completed", False):
+        return False
+
+    if record.get("config_signature") != get_config_signature(data):
+        return False
+
+    return record.get("params", {}) == (params or {})
+
+
+def mark_stage_complete(data, stage, params=None):
+    status = load_stage_status(data)
+    status[stage] = {
+        "completed": True,
+        "config_signature": get_config_signature(data),
+        "params": params or {},
+    }
+    save_stage_status(data, status)
 
 
 def check_skip(data, skip, trs):
@@ -28,6 +106,13 @@ def launch_mappers(data, skip=None, stop_at_error=False):
     Launch the computation of mappers for all tracers in data.
     This is a preliminary step to precompute the heavy parts
     """
+    stage_params = {"skip": sorted(skip) if skip else []}
+    if stage_is_complete(data, "mappers", stage_params):
+        if RANK == 0:
+            print("[Rank 0] Mapper stage already completed, skipping.", flush=True)
+        COMM.Barrier()
+        return
+
     tracers_used = data.get_tracers_used()
 
     if RANK == 0:
@@ -67,6 +152,8 @@ def launch_mappers(data, skip=None, stop_at_error=False):
         counter += 1
 
     print(f"[Rank {RANK}] Mapper pre-computation finished.", flush=True)
+    if RANK == 0:
+        mark_stage_complete(data, "mappers", stage_params)
     COMM.Barrier()
 
 
@@ -75,6 +162,13 @@ def launch_cls(data, fiducial=False, skip=None, stop_at_error=False):
     Launch the computation of Cls for all tracers in data.
     If fiducial is True, compute the fiducial Cls.
     """
+    stage_params = {"fiducial": fiducial, "skip": sorted(skip) if skip else []}
+    if stage_is_complete(data, "cls", stage_params):
+        if RANK == 0:
+            print("[Rank 0] Cl stage already completed, skipping.", flush=True)
+        COMM.Barrier()
+        return
+
     cl_tracers = data.get_cl_trs_names()
     cl_tracers_per_wsp = data.get_cl_tracers_per_wsp()
 
@@ -149,6 +243,8 @@ def launch_cls(data, fiducial=False, skip=None, stop_at_error=False):
             counter += 1
 
     print(f"[Rank {RANK}] Cl computation finished.", flush=True)
+    if RANK == 0:
+        mark_stage_complete(data, "cls", stage_params)
     COMM.Barrier()
 
 
@@ -156,6 +252,17 @@ def launch_cov(data, skip=[], stop_at_error=False, save_cw=True, override=False)
     """
     Launch the computation of Covariance blocks for all tracers in data.
     """
+    stage_params = {
+        "skip": sorted(skip) if skip else [],
+        "save_cw": save_cw,
+        "override": override,
+    }
+    if stage_is_complete(data, "cov", stage_params):
+        if RANK == 0:
+            print("[Rank 0] Covariance stage already completed, skipping.", flush=True)
+        COMM.Barrier()
+        return
+
     cov_tracers = data.get_cov_trs_names()
     cov_tracers_per_cwsp = data.get_cov_tracers_per_cwsp()
 
@@ -234,6 +341,8 @@ def launch_cov(data, skip=[], stop_at_error=False, save_cw=True, override=False)
             counter += 1
 
     print(f"[Rank {RANK}] Covariance computation finished.")
+    if RANK == 0:
+        mark_stage_complete(data, "cov", stage_params)
     COMM.Barrier()
 
 
@@ -243,10 +352,18 @@ def launch_to_sacc(data, fname, use, m_marg):
     If use is 'nl', use the noise covariance instead of the Cls.
     If use is 'fiducial', use the fiducial Cls instead of the data Cls.
     """
+    stage_params = {"use": use, "m_marg": m_marg}
+    if stage_is_complete(data, "to_sacc", stage_params):
+        if RANK == 0:
+            print("[Rank 0] Sacc stage already completed, skipping.", flush=True)
+        COMM.Barrier()
+        return
+
     if RANK == 0:
         print(f"Converting to Sacc format using {use}...", flush=True)
 
-        sacc = ClSack(data, fname, use, m_marg)
+        sacc = ClSack(data.data_path, fname, use, m_marg)
+        mark_stage_complete(data, "to_sacc", stage_params)
 
     COMM.Barrier()
 
@@ -339,8 +456,7 @@ if __name__ == "__main__":
     # Broadcast the data object from rank 0 to all ranks
     data = COMM.bcast(data, root=0)
 
-    # 0. TODO: We could loop over the mappers to make sure the heavy parts have
-    # been precomputed.
+    # 0. Loop over the mappers to make sure the heavy parts have been computed.
     launch_mappers(data, skip=args.skip, stop_at_error=args.stop_at_error)
 
     # 1. Compute Cells
@@ -385,7 +501,7 @@ if __name__ == "__main__":
 
     m_marg = args.to_sacc_m_marg == "m_marg"
     launch_to_sacc(
-        data.data_path, fname=args.to_sacc_name, use=use, m_marg=m_marg
+        data, fname=args.to_sacc_name, use=use, m_marg=m_marg
     )
 
     if RANK == 0:


### PR DESCRIPTION
This PR fixes the MC correction cache and modifies the `run_cls_mpi.py` so it can be run without MPI (e.g. when you want to just create the sacc file, because that is done in a single job).

@damonge let me know if you want me to remove the old script `run_cls.py`. 